### PR TITLE
fix: run npm audit to fix known vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3532,10 +3532,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "http://registry.npm.taobao.org/eslint-utils/download/eslint-utils-1.3.1.tgz",
-      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -5980,9 +5983,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "http://registry.npm.taobao.org/lodash/download/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._getnative": {
       "version": "3.9.1",


### PR DESCRIPTION
After downloading the project, and installing node dependencies, the npm vulnerability scanner identified 192 issues, which have been fixed by running `npm audit`.